### PR TITLE
Enhance ImagePicker options with 'withUCropOptions'

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,23 @@ ImagePicker
 - **Limit MIME types:** `.galleryMimeTypes(mimeTypes = arrayOf("image/png", "image/jpg", "image/jpeg"))`
 - **Camera option only (without gallery):** `.cameraOnly()`
 - **Gallery option only (without camera):** `.galleryOnly()`
+- **User can freely choose the ratio of the cropped image:** `.cropFreeStyle()`
 
+**Use any of the uCrop options:**
+
+```kotlin
+ImagePicker
+    .with(this)
+    .withUCropOptions { options ->
+        options.withAspectRatio(1f, 1f)
+        options.setCircleDimmedLayer(true)
+        options.setCompressionQuality(10)
+        // Add more UCrop options as needed
+    }.provider(ImageProvider.BOTH)
+    .createIntentFromDialog { profileLauncher.launch(it) }
+```
+
+More options are described [here](https://github.com/jens-muenker/uCrop-n-Edit/blob/master/UCrop-Options.md).
 
 **Java sample for using `createIntentFromDialog`:**
 
@@ -156,13 +172,6 @@ ImagePicker.Companion
             launcher.launch(it);
         }
     }));
-```
-
-**Let the user to resize crop bounds:**
-
-```kotlin
-.crop()                                                  
-.cropFreeStyle()
 ```
 
 **Intercept ImageProvider; could be used for analytics purposes:**

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 buildscript {
     ext {
         kotlin_version = '2.1.20'
-        versionCode = 45
-        versionName = '2.4.1'
+        versionCode = 46
+        versionName = '2.5.0'
     }
 
     repositories {

--- a/imagepicker/build.gradle
+++ b/imagepicker/build.gradle
@@ -55,8 +55,8 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.7'
     implementation 'androidx.fragment:fragment-ktx:1.8.6'
 
-    //More Info: https://github.com/jens-muenker/uCrop-n-Edit
-    implementation 'com.github.jens-muenker:uCrop-n-Edit:4.1.0'
+    // See GitHub repo: https://github.com/jens-muenker/uCrop-n-Edit
+    api 'com.github.jens-muenker:uCrop-n-Edit:4.1.0'
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'

--- a/imagepicker/src/main/kotlin/io/github/catlandor/imagepicker/ImagePickerActivity.kt
+++ b/imagepicker/src/main/kotlin/io/github/catlandor/imagepicker/ImagePickerActivity.kt
@@ -168,8 +168,6 @@ class ImagePickerActivity : AppCompatActivity() {
             mCropProvider.isCropEnabled() ->
                 mCropProvider.startIntent(
                     uri = uri,
-                    cropOval = mCropProvider.isCropOvalEnabled(),
-                    cropFreeStyle = mCropProvider.isCropFreeStyleEnabled(),
                     isCamera = isCamera,
                     isMultipleFiles = false,
                     outputFormat = mCropProvider.outputFormat()
@@ -205,8 +203,6 @@ class ImagePickerActivity : AppCompatActivity() {
             mCropProvider.isCropEnabled() ->
                 mCropProvider.startIntent(
                     uri = uri,
-                    cropOval = mCropProvider.isCropOvalEnabled(),
-                    cropFreeStyle = mCropProvider.isCropFreeStyleEnabled(),
                     isCamera = false,
                     isMultipleFiles = true,
                     outputFormat = mCropProvider.outputFormat()

--- a/imagepicker/src/main/kotlin/io/github/catlandor/imagepicker/wrapper/UCropOptionsWrapper.kt
+++ b/imagepicker/src/main/kotlin/io/github/catlandor/imagepicker/wrapper/UCropOptionsWrapper.kt
@@ -1,0 +1,74 @@
+package io.github.catlandor.imagepicker.wrapper
+
+import android.graphics.Bitmap
+import android.os.Bundle
+import android.os.Parcel
+import android.os.Parcelable
+import com.yalantis.ucrop.UCrop
+
+class UCropOptionsWrapper(val options: UCrop.Options) : Parcelable {
+    constructor(parcel: Parcel) : this(
+        UCrop.Options().apply {
+            // Read options from parcel dynamically
+            val fieldMap = UCrop.Options::class.java.declaredFields.associateBy { it.name }
+            fieldMap.forEach { (name, field) ->
+                field.isAccessible = true
+                try {
+                    when (field.type) {
+                        Int::class.java -> field.setInt(this, parcel.readInt())
+                        Float::class.java -> field.setFloat(this, parcel.readFloat())
+                        Boolean::class.java ->
+                            field.setBoolean(
+                                this,
+                                parcel.readByte().toInt() != 0
+                            )
+
+                        String::class.java -> field.set(this, parcel.readString())
+                        Bitmap.CompressFormat::class.java ->
+                            field.set(
+                                this,
+                                parcel.readSerializable() as Bitmap.CompressFormat?
+                            )
+
+                        Bundle::class.java ->
+                            field.set(
+                                this,
+                                parcel.readBundle(Bundle::class.java.classLoader)
+                            )
+                    }
+                } catch (e: IllegalArgumentException) {
+                    // Skip unsupported fields
+                }
+            }
+        }
+    )
+
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        // Write options to parcel dynamically
+        val fieldMap = UCrop.Options::class.java.declaredFields.associateBy { it.name }
+        fieldMap.forEach { (_, field) ->
+            field.isAccessible = true
+            try {
+                when (val value = field.get(this.options)) {
+                    is Int -> parcel.writeInt(value)
+                    is Float -> parcel.writeFloat(value)
+                    is Boolean -> parcel.writeByte((if (value) 1 else 0).toByte())
+                    is String -> parcel.writeString(value)
+                    is Bitmap.CompressFormat -> parcel.writeSerializable(value)
+                    is Bundle -> parcel.writeBundle(value)
+                }
+            } catch (e: IllegalArgumentException) {
+                // Skip unsupported fields
+            }
+        }
+    }
+
+    override fun describeContents(): Int = 0
+
+    companion object CREATOR : Parcelable.Creator<UCropOptionsWrapper> {
+        override fun createFromParcel(parcel: Parcel): UCropOptionsWrapper =
+            UCropOptionsWrapper(parcel)
+
+        override fun newArray(size: Int): Array<UCropOptionsWrapper?> = arrayOfNulls(size)
+    }
+}

--- a/sample/src/main/kotlin/io.github.catlandor.imagepicker/sample/MainActivity.kt
+++ b/sample/src/main/kotlin/io.github.catlandor.imagepicker/sample/MainActivity.kt
@@ -139,7 +139,6 @@ class MainActivity : AppCompatActivity() {
     private fun pickProfileImage() {
         ImagePicker
             .with(this)
-            .crop()
             .cropOval()
             .maxResultSize(512, 512, true)
             .provider(ImageProvider.BOTH) // Or bothCameraGallery()
@@ -172,7 +171,7 @@ class MainActivity : AppCompatActivity() {
         cameraLauncher.launch(
             ImagePicker
                 .with(this)
-                .crop()
+                .crop(16f, 9f)
                 .cameraOnly()
                 .maxResultSize(1080, 1920, keepRatio = true)
                 .createIntent()


### PR DESCRIPTION
## Proposed changes

1. New option for the ImagePicker builder to directly use any of the available [uCrop options](https://github.com/jens-muenker/uCrop-n-Edit/blob/master/UCrop-Options.md).

Example:
```kotlin
ImagePicker
    .with(this)
    .withUCropOptions { options ->
        options.withAspectRatio(1f, 1f)
        options.setCircleDimmedLayer(true)
        options.setCompressionQuality(10)
        // Add more UCrop options as needed
    }.provider(ImageProvider.BOTH)
    .createIntentFromDialog { profileLauncher.launch(it) }
```

2. Improved the usage of existing options. `.cropOval()` / `.cropFreeStyle()` now does not need an `.crop()` option to work.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring of code (behavior of the application should not change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have rebased my PR to the origin of the default branch (master)
- [x] I have a clean commit history (usually just one commit)