### PR TITLE
#72: Allow ImagePicker companion object for gallery / camera only options

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,16 @@ ImagePicker
     .createIntentFromDialog { launcher.launch(it) }
 ```
 
+or (for `cameraOnly` and `galleryOnly`):
+
+```kotlin
+launcher.launch(
+    ImagePicker
+        .with(this)
+        .provider(ImageProvider.CAMERA)
+        .createIntent())
+```
+
 ### Java
 
 1. Register for activity result:

--- a/imagepicker/src/main/kotlin/io/github/catlandor/imagepicker/ImagePicker.kt
+++ b/imagepicker/src/main/kotlin/io/github/catlandor/imagepicker/ImagePicker.kt
@@ -285,6 +285,9 @@ open class ImagePicker {
                         },
                     dismissListener
                 )
+            } else if (imageProvider == ImageProvider.CAMERA || imageProvider == ImageProvider.GALLERY) {
+                imageProviderInterceptor?.invoke(imageProvider)
+                onResult(createIntent())
             }
         }
 

--- a/sample/src/androidTest/java/io/github/catlandor/imagepicker/CameraWithoutCropTests.kt
+++ b/sample/src/androidTest/java/io/github/catlandor/imagepicker/CameraWithoutCropTests.kt
@@ -1,5 +1,6 @@
 package io.github.catlandor.imagepicker
 
+import android.util.Log
 import android.widget.ImageView
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions
@@ -13,6 +14,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.Until
+import io.github.catlandor.imagepicker.constant.ImageProvider
 import io.github.catlandor.imagepicker.sample.MainActivity
 import io.github.catlandor.imagepicker.sample.R
 import org.junit.After
@@ -55,6 +57,25 @@ class CameraWithoutCropTests {
             )
         }
 
+        performCameraAssertions()
+    }
+
+    @Test
+    fun cameraLauncher_WithImagePicker_ActionPerformed() {
+        activityScenarioRule.scenario.onActivity { activity: MainActivity ->
+            ImagePicker
+                .with(activity)
+                .maxResultSize(512, 512, true)
+                .provider(ImageProvider.CAMERA)
+                .setDismissListener {
+                    Log.d("ImagePicker", "onDismiss")
+                }.createIntentFromDialog { activity.cameraLauncher.launch(it) }
+        }
+
+        performCameraAssertions()
+    }
+
+    private fun performCameraAssertions() {
         TestUtils.tryClickCameraLocationAllowButton(
             device,
             threadTimeout,


### PR DESCRIPTION
## Proposed changes

Enables to use following usage for `.galleryOnly` and `.cameraOnly`:

```
ImagePicker
    .with(this)
    .cropOval()
    .maxResultSize(512, 512, true)
    .provider(ImageProvider.CAMERA)
    .setDismissListener {
        Log.d("ImagePicker", "onDismiss")
    }.createIntentFromDialog { profileLauncher.launch(it) }
```

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring of code (behavior of the application should not change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] I have rebased my PR to the origin of the default branch (main)
- [x] I have a clean commit history (usually just one commit)