### PR TITLE
Bump version to 3.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 buildscript {
     ext {
         kotlin_version = '2.3.0'
-        versionCode = 47
-        versionName = '2.5.1'
+        versionCode = 48
+        versionName = '3.0.0'
     }
 
     repositories {


### PR DESCRIPTION
## Proposed changes

Bump version to 3.0.0

3.0.0 as a major version, since the [min. SDK version was raised from 21 to 23](https://github.com/Catlandor/ImagePicker/pull/94)

A minor version is also included due to a new version of [uCrop-n-Edit](https://github.com/jens-muenker/uCrop-n-Edit), now supporting custom colors for the background such as the progress wheel.