### PR TITLE
Fix IllegalAccessException crash when restoring UCropOptionsWrapper from Parcel

### DIFF
--- a/imagepicker/src/androidTest/java/io/github/catlandor/imagepicker/wrapper/UCropOptionsWrapperTests.kt
+++ b/imagepicker/src/androidTest/java/io/github/catlandor/imagepicker/wrapper/UCropOptionsWrapperTests.kt
@@ -1,0 +1,22 @@
+package io.github.catlandor.imagepicker.wrapper
+
+import android.os.Parcel
+import com.yalantis.ucrop.UCrop
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class UCropOptionsWrapperTests {
+    @Test
+    fun optionsSurviveParcelRoundTrip() {
+        val options = UCrop.Options().apply { setCompressionQuality(42) }
+        val parcel = Parcel.obtain()
+        UCropOptionsWrapper(options).writeToParcel(parcel, 0)
+        parcel.setDataPosition(0)
+        val restored = UCropOptionsWrapper.createFromParcel(parcel)
+        assertEquals(
+            42,
+            restored.options.optionBundle.getInt(UCrop.Options.EXTRA_COMPRESSION_QUALITY)
+        )
+        parcel.recycle()
+    }
+}

--- a/imagepicker/src/main/kotlin/io/github/catlandor/imagepicker/wrapper/UCropOptionsWrapper.kt
+++ b/imagepicker/src/main/kotlin/io/github/catlandor/imagepicker/wrapper/UCropOptionsWrapper.kt
@@ -5,12 +5,20 @@ import android.os.Bundle
 import android.os.Parcel
 import android.os.Parcelable
 import com.yalantis.ucrop.UCrop
+import java.lang.reflect.Modifier
+
+// Static/constant fields (e.g. UCrop.Options.EXTRA_ALLOWED_GESTURES) aren't part of an
+// instance's state and reflectively writing to them throws IllegalAccessException, so they
+// must be excluded from both directions of the (de)serialization below.
+private val instanceFields =
+    UCrop.Options::class.java.declaredFields
+        .filterNot { Modifier.isStatic(it.modifiers) }
 
 class UCropOptionsWrapper(val options: UCrop.Options) : Parcelable {
     constructor(parcel: Parcel) : this(
         UCrop.Options().apply {
             // Read options from parcel dynamically
-            val fieldMap = UCrop.Options::class.java.declaredFields.associateBy { it.name }
+            val fieldMap = instanceFields.associateBy { it.name }
             fieldMap.forEach { (name, field) ->
                 field.isAccessible = true
                 try {
@@ -50,6 +58,8 @@ class UCropOptionsWrapper(val options: UCrop.Options) : Parcelable {
                     }
                 } catch (e: IllegalArgumentException) {
                     // Skip unsupported fields
+                } catch (e: IllegalAccessException) {
+                    // Skip fields that reflection isn't allowed to write (e.g. static constants)
                 }
             }
         }
@@ -57,7 +67,7 @@ class UCropOptionsWrapper(val options: UCrop.Options) : Parcelable {
 
     override fun writeToParcel(parcel: Parcel, flags: Int) {
         // Write options to parcel dynamically
-        val fieldMap = UCrop.Options::class.java.declaredFields.associateBy { it.name }
+        val fieldMap = instanceFields.associateBy { it.name }
         fieldMap.forEach { (_, field) ->
             field.isAccessible = true
             try {

--- a/imagepicker/src/main/kotlin/io/github/catlandor/imagepicker/wrapper/UCropOptionsWrapper.kt
+++ b/imagepicker/src/main/kotlin/io/github/catlandor/imagepicker/wrapper/UCropOptionsWrapper.kt
@@ -1,88 +1,20 @@
 package io.github.catlandor.imagepicker.wrapper
 
-import android.graphics.Bitmap
-import android.os.Bundle
 import android.os.Parcel
 import android.os.Parcelable
 import com.yalantis.ucrop.UCrop
-import java.lang.reflect.Modifier
-
-// Static/constant fields (e.g. UCrop.Options.EXTRA_ALLOWED_GESTURES) aren't part of an
-// instance's state and reflectively writing to them throws IllegalAccessException, so they
-// must be excluded from both directions of the (de)serialization below.
-private val instanceFields =
-    UCrop.Options::class.java.declaredFields
-        .filterNot { Modifier.isStatic(it.modifiers) }
 
 class UCropOptionsWrapper(val options: UCrop.Options) : Parcelable {
     constructor(parcel: Parcel) : this(
         UCrop.Options().apply {
-            // Read options from parcel dynamically
-            val fieldMap = instanceFields.associateBy { it.name }
-            fieldMap.forEach { (name, field) ->
-                field.isAccessible = true
-                try {
-                    when (field.type) {
-                        Int::class.java -> {
-                            field.setInt(this, parcel.readInt())
-                        }
-
-                        Float::class.java -> {
-                            field.setFloat(this, parcel.readFloat())
-                        }
-
-                        Boolean::class.java -> {
-                            field.setBoolean(
-                                this,
-                                parcel.readByte().toInt() != 0
-                            )
-                        }
-
-                        String::class.java -> {
-                            field.set(this, parcel.readString())
-                        }
-
-                        Bitmap.CompressFormat::class.java -> {
-                            field.set(
-                                this,
-                                parcel.readSerializable() as Bitmap.CompressFormat?
-                            )
-                        }
-
-                        Bundle::class.java -> {
-                            field.set(
-                                this,
-                                parcel.readBundle(Bundle::class.java.classLoader)
-                            )
-                        }
-                    }
-                } catch (e: IllegalArgumentException) {
-                    // Skip unsupported fields
-                } catch (e: IllegalAccessException) {
-                    // Skip fields that reflection isn't allowed to write (e.g. static constants)
-                }
-            }
+            parcel
+                .readBundle(UCrop.Options::class.java.classLoader)
+                ?.let { optionBundle.putAll(it) }
         }
     )
 
     override fun writeToParcel(parcel: Parcel, flags: Int) {
-        // Write options to parcel dynamically
-        val fieldMap = instanceFields.associateBy { it.name }
-        fieldMap.forEach { (_, field) ->
-            field.isAccessible = true
-            try {
-                when (val value = field.get(this.options)) {
-                    is Int -> parcel.writeInt(value)
-                    is Float -> parcel.writeFloat(value)
-                    is Boolean -> parcel.writeByte((if (value) 1 else 0).toByte())
-                    is String -> parcel.writeString(value)
-                    is Bitmap.CompressFormat -> parcel.writeSerializable(value)
-                    is Bundle -> parcel.writeBundle(value)
-                }
-            } catch (e: IllegalArgumentException) {
-                // Skip unsupported fields
-            }
-        }
+        parcel.writeBundle(options.optionBundle)
     }
 
     override fun describeContents(): Int = 0


### PR DESCRIPTION
## Problem

`UCropOptionsWrapper` reflects over all `UCrop.Options` declared fields to (de)serialize it, including static constants such as `EXTRA_ALLOWED_GESTURES`. Writing to a `public static final` field via reflection throws `IllegalAccessException`, which isn't caught by the existing `catch (e: IllegalArgumentException)` block, so it propagates up and crashes `ImagePickerActivity` whenever the `Options` `Parcelable` is unmarshalled (e.g. on activity recreation / restoring launch extras).

Observed in production via Firebase Crashlytics:

```
java.lang.IllegalAccessException: Cannot set public static final field java.lang.String com.yalantis.ucrop.UCrop$Options.EXTRA_ALLOWED_GESTURES of class java.lang.Class<com.yalantis.ucrop.UCrop$Options>
	at java.lang.reflect.Field.set (Field.java)
	at io.github.catlandor.imagepicker.wrapper.UCropOptionsWrapper.<init> (UCropOptionsWrapper.java:34)
	at io.github.catlandor.imagepicker.wrapper.UCropOptionsWrapper$CREATOR.createFromParcel (UCropOptionsWrapper.kt:82)
	at android.os.Parcel.readParcelableInternal (Parcel.java:5281)
	...
	at io.github.catlandor.imagepicker.provider.CropProvider.<init> (CropProvider.kt:54)
	at io.github.catlandor.imagepicker.ImagePickerActivity.loadBundle (ImagePickerActivity.kt:107)
	at io.github.catlandor.imagepicker.ImagePickerActivity.onCreate (ImagePickerActivity.kt:74)
```

## Fix

- Exclude static fields from the field set used for (de)serialization, kept identical between `writeToParcel` and the `Parcel` constructor so read/write stay positionally consistent.
- Add a defensive `catch (e: IllegalAccessException)` alongside the existing `IllegalArgumentException` catch, in case reflection hits a non-writable field for any other reason in the future.

## Testing

- `./gradlew :imagepicker:compileDebugKotlin` — passes
- `./gradlew :imagepicker:ktlintCheck` — passes